### PR TITLE
[Minor] Exchange "0 += 1" for "0 = 1" in UnifiedDiffUtils

### DIFF
--- a/src/main/java/com/github/difflib/UnifiedDiffUtils.java
+++ b/src/main/java/com/github/difflib/UnifiedDiffUtils.java
@@ -83,10 +83,10 @@ public final class UnifiedDiffUtils {
                 new_ln = m.group(3) == null ? 1 : Integer.parseInt(m.group(3));
 
                 if (old_ln == 0) {
-                    old_ln += 1;
+                    old_ln = 1;
                 }
                 if (new_ln == 0) {
-                    new_ln += 1;
+                    new_ln = 1;
                 }
             } else {
                 if (line.length() > 0) {


### PR DESCRIPTION
the line
```java
if(new_ln == 0) {
    new_ln += 1;
}
```
is equivalent in its result to 
```java
if(new_ln == 0) {
    new_ln = 1;
}
```
, but is converted to more instructions within the JVM than just assigning a new value. This should only gain very littly performance, but is more reasonable to do.