### PR TITLE
Fix linting issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # java-diff-utils
 
-## Status ##
+## Status
+
 [![Build Status](https://travis-ci.org/java-diff-utils/java-diff-utils.svg?branch=master)](https://travis-ci.org/java-diff-utils/java-diff-utils)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/7eba77f10bed4c2a8d08ac8dc8da4a86)](https://www.codacy.com/app/wumpz/java-diff-utils?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=java-diff-utils/java-diff-utils&amp;utm_campaign=Badge_Grade)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.java-diff-utils/java-diff-utils/badge.svg)](http://maven-badges.herokuapp.com/maven-central/io.github.java-diff-utils/java-diff-utils)
 
+## Intro
 
-## Intro ##
 Diff Utils library is an OpenSource library for performing the comparison operations between texts: computing diffs, applying patches, generating unified diffs or parsing them, generating diff output for easy future displaying (like side-by-side view) and so on.
 
 Main reason to build this library was the lack of easy-to-use libraries with all the usual stuff you need while working with diff files. Originally it was inspired by JRCS library and it's nice design of diff module.
 
 **This is originally a fork of java-diff-utils from Google Code Archive.**
 
-## Examples ##
+## Examples
 
-Look [here](https://github.com/wumpz/java-diff-utils/wiki) to find more helpful informations and examples. 
+Look [here](https://github.com/wumpz/java-diff-utils/wiki) to find more helpful informations and examples.
 
 These two outputs are generated using this java-diff-utils. The source code can also be found at the *Examples* page:
 
 **Producing a one liner including all difference information.**
 
 This is a test ~senctence~**for diffutils**.
-
 
 **Producing a side by side view of computed differences.**
 
@@ -32,23 +32,22 @@ This is a test ~senctence~**for diffutils**.
 |This is the second line.|This is the second line.|
 |~And here is the finish.~||
 
+## Main Features
 
-## Main Features ##
+* computing the difference between two texts.
+* capable to hand more than plain ascci. Arrays or List of any type that implements hashCode() and equals() correctly can be subject to differencing using this library
+* patch and unpatch the text with the given patch
+* parsing the unified diff format
+* producing human-readable differences
+* inline difference construction
+* Algorithms:
+  * Myer
+  * HistogramDiff using JGit Library
 
-  * computing the difference between two texts.
-  * capable to hand more than plain ascci. Arrays or List of any type that implements hashCode() and equals() correctly can be subject to differencing using this library
-  * patch and unpatch the text with the given patch
-  * parsing the unified diff format
-  * producing human-readable differences
-  * inline difference construction
-  * Algorithms:
-    * Myer
-    * HistogramDiff using JGit Library
-
-### Algoritms ###
+### Algoritms
 
 * Myer's diff
-* HistogramDiff 
+* HistogramDiff
 
 But it can easily replaced by any other which is better for handing your texts. I have plan to add implementation of some in future.
 
@@ -91,24 +90,26 @@ Recently a checkstyle process was integrated into the build process. java-diff-u
 
 ```java
 public static <T> Patch<T> diff(List<T> original, List<T> revised,
-	BiPredicate<T, T> equalizer) throws DiffException {
-	if (equalizer != null) {
-		return DiffUtils.diff(original, revised,
-				new MyersDiff<>(equalizer));
-	}
-	return DiffUtils.diff(original, revised, new MyersDiff<>());
+    BiPredicate<T, T> equalizer) throws DiffException {
+    if (equalizer != null) {
+        return DiffUtils.diff(original, revised,
+        new MyersDiff<>(equalizer));
+    }
+    return DiffUtils.diff(original, revised, new MyersDiff<>());
 }
 ```
 
 This is a valid piece of source code:
+
 * blocks without braces are not allowed
 * after control statements (if, while, for) a whitespace is expected
 * the opening brace should be in the same line as the control statement
 
-### To Install ###
+### To Install
 
 Just add the code below to your maven dependencies:
-```
+
+```xml
 <dependency>
     <groupId>io.github.java-diff-utils</groupId>
     <artifactId>java-diff-utils</artifactId>
@@ -118,7 +119,7 @@ Just add the code below to your maven dependencies:
 
 Attention. We changed groupid and artifactid. Starting with version 4 you have to use:
 
-```
+```xml
 <dependency>
     <groupId>io.github.java-diff-utils</groupId>
     <artifactId>java-diff-utils</artifactId>
@@ -127,7 +128,8 @@ Attention. We changed groupid and artifactid. Starting with version 4 you have t
 ```
 
 or using gradle:
-```
+
+```groovy
 // https://mvnrepository.com/artifact/com.github.wumpz/diffutils
 compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
 ```


### PR DESCRIPTION
I used the [VS Code Markdown Linter](https://github.com/DavidAnson/vscode-markdownlint) and fixed issues found in README.md.

I did not touch the section "Changelog", because of #35.