### PR TITLE
Add support for IntelliJ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-/target/
-/nbproject/
+.idea/
+build/
+nbproject/
+target/


### PR DESCRIPTION
I am using IntelliJ instead of Netbeans. This .gitignore update would help others using IntelliJ, too.

I was going to use the full-fledged gitignore file generated by <https://www.gitignore.io/>. However, not all persons are "trusting" [GitHub's gitignore files](https://github.com/github/gitignore).