### PR TITLE
Fix section heading messing up unified parsing

### DIFF
--- a/src/main/java/com/github/difflib/UnifiedDiffUtils.java
+++ b/src/main/java/com/github/difflib/UnifiedDiffUtils.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
 public final class UnifiedDiffUtils {
 
     private static final Pattern UNIFIED_DIFF_CHUNK_REGEXP = Pattern
-            .compile("^@@\\s+-(?:(\\d+)(?:,(\\d+))?)\\s+\\+(?:(\\d+)(?:,(\\d+))?)\\s+@@$");
+            .compile("^@@\\s+-(?:(\\d+)(?:,(\\d+))?)\\s+\\+(?:(\\d+)(?:,(\\d+))?)\\s+@@(\\s.*)?$");
 
     /**
      * Parse the given text in unified format and creates the list of deltas for it.


### PR DESCRIPTION
Fixed #33

Repo:
```
--- a/Main.java
+++ b/Main.java
@@ -2,2 +2,3 @@ public class Main {
     public static void main(String[] args) {
+        System.out.println("Hello, world!");
     }
```