### PR TITLE
StringUtils.wrapText will not split surrogate pair.

### DIFF
--- a/java-diff-utils/src/main/java/com/github/difflib/text/StringUtils.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/text/StringUtils.java
@@ -21,10 +21,10 @@ import static java.util.stream.Collectors.toList;
 final class StringUtils {
 
     /**
-     * Replaces all opening an closing tags with <code>&lt;</code> or <code>&gt;</code>.
+     * Replaces all opening and closing tags with <code>&lt;</code> or <code>&gt;</code>.
      *
      * @param str
-     * @return
+     * @return str with some HTML meta characters escaped.
      */
     public static String htmlEntites(String str) {
         return str.replace("<", "&lt;").replace(">", "&gt;");
@@ -61,7 +61,17 @@ final class StringUtils {
         StringBuilder b = new StringBuilder(line);
 
         for (int count = 0; length > widthIndex; count++) {
-            b.insert(widthIndex + delimiter * count, "<br/>");
+            int breakPoint = widthIndex + delimiter * count;
+            if (Character.isHighSurrogate(b.charAt(breakPoint - 1)) &&
+                Character.isLowSurrogate(b.charAt(breakPoint))) {
+              // Shift a breakpoint that would split a supplemental code-point.
+              breakPoint += 1;
+              if (breakPoint == b.length()) {
+                // Break before instead of after if this is the last code-point.
+                breakPoint -= 2;
+              }
+            }
+            b.insert(breakPoint, "<br/>");
             widthIndex += columnWidth;
         }
 

--- a/java-diff-utils/src/test/java/com/github/difflib/text/StringUtilsTest.java
+++ b/java-diff-utils/src/test/java/com/github/difflib/text/StringUtilsTest.java
@@ -49,6 +49,8 @@ public class StringUtilsTest {
         assertEquals("te<br/>st", StringUtils.wrapText("test", 2));
         assertEquals("tes<br/>t", StringUtils.wrapText("test", 3));
         assertEquals("test", StringUtils.wrapText("test", 10));
+        assertEquals(".\uD800\uDC01<br/>.", StringUtils.wrapText(".\uD800\uDC01.", 2));
+        assertEquals("..<br/>\uD800\uDC01", StringUtils.wrapText("..\uD800\uDC01", 3));
     }
 
     @Test


### PR DESCRIPTION
Previously,

    StringUtils.wrapText(".\uD800\uDC00.", 2)
    //                           ^ index 2 points here

would insert a `<br/>` between two paired surrogates.

Now, it shifts the insertion point to a whole code-point boundary.