### PR TITLE
Eliminate most unchecked and unsafe operation warnings

### DIFF
--- a/java-diff-utils-jgit/src/test/java/com/github/difflib/algorithm/jgit/HistogramDiffTest.java
+++ b/java-diff-utils-jgit/src/test/java/com/github/difflib/algorithm/jgit/HistogramDiffTest.java
@@ -41,7 +41,7 @@ public class HistogramDiffTest {
     public void testDiff() throws PatchFailedException {
         List<String> orgList = Arrays.asList("A", "B", "C", "A", "B", "B", "A");
         List<String> revList = Arrays.asList("C", "B", "A", "B", "A", "C");
-        final Patch<String> patch = Patch.generate(orgList, revList, new HistogramDiff().computeDiff(orgList, revList, null));
+        final Patch<String> patch = Patch.generate(orgList, revList, new HistogramDiff<String>().computeDiff(orgList, revList, null));
         System.out.println(patch);
         assertNotNull(patch);
         assertEquals(3, patch.getDeltas().size());
@@ -57,7 +57,7 @@ public class HistogramDiffTest {
         List<String> revList = Arrays.asList("C", "B", "A", "B", "A", "C");
         
         List<String> logdata = new ArrayList<>();
-        final Patch<String> patch = Patch.generate(orgList, revList, new HistogramDiff().computeDiff(orgList, revList, new DiffAlgorithmListener() {
+        final Patch<String> patch = Patch.generate(orgList, revList, new HistogramDiff<String>().computeDiff(orgList, revList, new DiffAlgorithmListener() {
             @Override
             public void diffStart() {
                 logdata.add("start");

--- a/java-diff-utils-jgit/src/test/java/com/github/difflib/algorithm/jgit/LRHistogramDiffTest.java
+++ b/java-diff-utils-jgit/src/test/java/com/github/difflib/algorithm/jgit/LRHistogramDiffTest.java
@@ -45,7 +45,7 @@ public class LRHistogramDiffTest {
         List<String> revised = readStringListFromInputStream(zip.getInputStream(zip.getEntry("tb")));
 
         List<String> logdata = new ArrayList<>();
-        Patch<String> patch = Patch.generate(original, revised, new HistogramDiff().computeDiff(original, revised, new DiffAlgorithmListener() {
+        Patch<String> patch = Patch.generate(original, revised, new HistogramDiff<String>().computeDiff(original, revised, new DiffAlgorithmListener() {
             @Override
             public void diffStart() {
                 logdata.add("start");

--- a/java-diff-utils/src/main/java/com/github/difflib/patch/ChangeDelta.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/patch/ChangeDelta.java
@@ -75,6 +75,6 @@ public final class ChangeDelta<T> extends AbstractDelta<T> {
 
     @Override
     public AbstractDelta<T> withChunks(Chunk<T> original, Chunk<T> revised) {
-        return new ChangeDelta(original, revised);
+        return new ChangeDelta<T>(original, revised);
     }
 }

--- a/java-diff-utils/src/main/java/com/github/difflib/patch/Chunk.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/patch/Chunk.java
@@ -156,7 +156,7 @@ public final class Chunk<T> implements Serializable {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        Chunk<T> other = (Chunk) obj;
+        Chunk<?> other = (Chunk<?>) obj;
         if (lines == null) {
             if (other.lines != null) {
                 return false;

--- a/java-diff-utils/src/main/java/com/github/difflib/patch/DeleteDelta.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/patch/DeleteDelta.java
@@ -62,6 +62,6 @@ public final class DeleteDelta<T> extends AbstractDelta<T> {
     
     @Override
     public AbstractDelta<T> withChunks(Chunk<T> original, Chunk<T> revised) {
-        return new DeleteDelta(original, revised);
+        return new DeleteDelta<T>(original, revised);
     }
 }

--- a/java-diff-utils/src/main/java/com/github/difflib/patch/EqualDelta.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/patch/EqualDelta.java
@@ -44,6 +44,6 @@ public class EqualDelta<T> extends AbstractDelta<T> {
     
     @Override
     public AbstractDelta<T> withChunks(Chunk<T> original, Chunk<T> revised) {
-        return new EqualDelta(original, revised);
+        return new EqualDelta<T>(original, revised);
     }
 }

--- a/java-diff-utils/src/main/java/com/github/difflib/patch/InsertDelta.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/patch/InsertDelta.java
@@ -62,6 +62,6 @@ public final class InsertDelta<T> extends AbstractDelta<T> {
     
     @Override
     public AbstractDelta<T> withChunks(Chunk<T> original, Chunk<T> revised) {
-        return new InsertDelta(original, revised);
+        return new InsertDelta<T>(original, revised);
     }
 }

--- a/java-diff-utils/src/main/java/com/github/difflib/patch/Patch.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/patch/Patch.java
@@ -125,7 +125,7 @@ public final class Patch<T> implements Serializable {
         for (Change change : changes) {
 
             if (includeEquals && startOriginal < change.startOriginal) {
-                patch.addDelta(new EqualDelta(
+                patch.addDelta(new EqualDelta<T>(
                         buildChunk(startOriginal, change.startOriginal, original),
                         buildChunk(startRevised, change.startRevised, revised)));
             }
@@ -150,7 +150,7 @@ public final class Patch<T> implements Serializable {
         }
 
         if (includeEquals && startOriginal < original.size()) {
-            patch.addDelta(new EqualDelta(
+            patch.addDelta(new EqualDelta<T>(
                     buildChunk(startOriginal, original.size(), original),
                     buildChunk(startRevised, revised.size(), revised)));
         }

--- a/java-diff-utils/src/test/java/com/github/difflib/DiffUtilsTest.java
+++ b/java-diff-utils/src/test/java/com/github/difflib/DiffUtilsTest.java
@@ -112,7 +112,7 @@ public class DiffUtilsTest {
 
         final Patch<Integer> patch = DiffUtils.diff(original, revised);
 
-        for (AbstractDelta delta : patch.getDeltas()) {
+        for (AbstractDelta<Integer> delta : patch.getDeltas()) {
             System.out.println(delta);
         }
 

--- a/java-diff-utils/src/test/java/com/github/difflib/GenerateUnifiedDiffTest.java
+++ b/java-diff-utils/src/test/java/com/github/difflib/GenerateUnifiedDiffTest.java
@@ -147,7 +147,7 @@ public class GenerateUnifiedDiffTest {
 
     private void validateChangePosition(Patch<String> patch, int index, List<Integer> realRemoveList,
                                         List<Integer> realAddList ) {
-        final Chunk originChunk = patch.getDeltas().get(index).getSource();
+        final Chunk<String> originChunk = patch.getDeltas().get(index).getSource();
         List<Integer> removeList = originChunk.getChangePosition();
         assertEquals(realRemoveList.size(), removeList.size());
         for (Integer ele: realRemoveList) {
@@ -156,7 +156,7 @@ public class GenerateUnifiedDiffTest {
         for (Integer ele: removeList) {
             assertTrue(realAddList.contains(ele));
         }
-        final Chunk targetChunk = patch.getDeltas().get(index).getTarget();
+        final Chunk<String> targetChunk = patch.getDeltas().get(index).getTarget();
         List<Integer> addList = targetChunk.getChangePosition();
         assertEquals(realAddList.size(), addList.size());
         for (Integer ele: realAddList) {

--- a/java-diff-utils/src/test/java/com/github/difflib/unifieddiff/UnifiedDiffWriterTest.java
+++ b/java-diff-utils/src/test/java/com/github/difflib/unifieddiff/UnifiedDiffWriterTest.java
@@ -46,7 +46,7 @@ public class UnifiedDiffWriterTest {
         UnifiedDiff diff = UnifiedDiffReader.parseUnifiedDiff(new ByteArrayInputStream(str.getBytes()));
 
         StringWriter writer = new StringWriter();
-        UnifiedDiffWriter.write(diff, f -> Collections.EMPTY_LIST, writer, 5);
+        UnifiedDiffWriter.write(diff, f -> Collections.emptyList(), writer, 5);
         System.out.println(writer.toString());
     }
     


### PR DESCRIPTION
This commit eliminates all but one javac warning about unchecked code or unsafe operations.  The final warning is due to the cast on line 71 of java-diff-utils/src/test/java/com/github/difflib/patch/PatchTest.java, but that seems difficult to eliminate.