### PR TITLE
MyersDiff: `DEFAULT_EQUALIZER` should not be reused per instance

### DIFF
--- a/java-diff-utils/src/main/java/com/github/difflib/algorithm/myers/MyersDiff.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/algorithm/myers/MyersDiff.java
@@ -30,11 +30,10 @@ import java.util.function.BiPredicate;
  */
 public final class MyersDiff<T> implements DiffAlgorithmI<T> {
 
-    private static final BiPredicate<T, T> DEFAULT_EQUALIZER = Object::equals;
     private final BiPredicate<T, T> equalizer;
 
     public MyersDiff() {
-        equalizer = DEFAULT_EQUALIZER;
+        equalizer = Objects::equals; // DEFAULT_EQUALIZER
     }
 
     public MyersDiff(final BiPredicate<T, T> equalizer) {

--- a/java-diff-utils/src/main/java/com/github/difflib/algorithm/myers/MyersDiff.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/algorithm/myers/MyersDiff.java
@@ -30,7 +30,7 @@ import java.util.function.BiPredicate;
  */
 public final class MyersDiff<T> implements DiffAlgorithmI<T> {
 
-    private final BiPredicate<T, T> DEFAULT_EQUALIZER = Object::equals;
+    private static final BiPredicate<T, T> DEFAULT_EQUALIZER = Object::equals;
     private final BiPredicate<T, T> equalizer;
 
     public MyersDiff() {


### PR DESCRIPTION
Constants should be static. In this case, that doesn't work due to generics.

Since it's only used in one place, I just used it directly there with a comment.