### PR TITLE
Fix typo in UnifiedDiff#spplyPatchTo(Predicate<String>, List<String>)

### DIFF
--- a/java-diff-utils/src/main/java/com/github/difflib/unifieddiff/UnifiedDiff.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/unifieddiff/UnifiedDiff.java
@@ -55,7 +55,7 @@ public final class UnifiedDiff {
         return tail;
     }
 
-    public List<String> spplyPatchTo(Predicate<String> findFile, List<String> originalLines) throws PatchFailedException {
+    public List<String> applyPatchTo(Predicate<String> findFile, List<String> originalLines) throws PatchFailedException {
         UnifiedDiffFile file = files.stream()
                 .filter(diff -> findFile.test(diff.getFromFile()))
                 .findFirst().orElse(null);

--- a/java-diff-utils/src/test/java/com/github/difflib/unifieddiff/UnifiedDiffRoundTripTest.java
+++ b/java-diff-utils/src/test/java/com/github/difflib/unifieddiff/UnifiedDiffRoundTripTest.java
@@ -150,7 +150,7 @@ public class UnifiedDiffRoundTripTest {
 //                Patch<String> fromUnifiedPatch = unifiedDiff.getFiles().get(0).getPatch();
 //                patchedLines = fromUnifiedPatch.applyTo(origLines);
 //            }
-            patchedLines = unifiedDiff.spplyPatchTo(file -> originalFile.equals(file), origLines);
+            patchedLines = unifiedDiff.applyPatchTo(file -> originalFile.equals(file), origLines);
             assertEquals(revLines.size(), patchedLines.size());
             for (int i = 0; i < revLines.size(); i++) {
                 String l1 = revLines.get(i);


### PR DESCRIPTION
Replaces the UnifiedDiff#spplyPatchTo method with UnifiedDiff#applyPatchTo and also fixes the relevant invocation in the UnifiedDiff round-trip test