### PR TITLE
Fixed a markdown syntax error in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DiffRowGenerator generator = DiffRowGenerator.create()
                 .showInlineDiffs(true)
                 .mergeOriginalRevised(true)
                 .inlineDiffByWord(true)
-                .oldTag(f -> "~")      //introduce markdown style for strikethrough
+                .oldTag(f -> "~~")     //introduce markdown style for strikethrough
                 .newTag(f -> "**")     //introduce markdown style for bold
                 .build();
 
@@ -48,7 +48,7 @@ List<DiffRow> rows = generator.generateDiffRows(
 System.out.println(rows.get(0).getOldLine());
 ```
 
-This is a test ~senctence~**for diffutils**.
+This is a test ~~senctence~~**for diffutils**.
 
 **Producing a side by side view of computed differences.**
 
@@ -56,7 +56,7 @@ This is a test ~senctence~**for diffutils**.
 DiffRowGenerator generator = DiffRowGenerator.create()
                 .showInlineDiffs(true)
                 .inlineDiffByWord(true)
-                .oldTag(f -> "~")
+                .oldTag(f -> "~~")
                 .newTag(f -> "**")
                 .build();
 List<DiffRow> rows = generator.generateDiffRows(
@@ -70,11 +70,11 @@ for (DiffRow row : rows) {
 }
 ```
 
-|original|new|
-|--------|---|
-|This is a test ~senctence~.|This is a test **for diffutils**.|
-|This is the second line.|This is the second line.|
-|~And here is the finish.~||
+| original                      |new|
+|-------------------------------|---|
+| This is a test ~~senctence~~. |This is a test **for diffutils**.|
+| This is the second line.      |This is the second line.|
+| ~~And here is the finish.~~   ||
 
 ## Main Features
 


### PR DESCRIPTION
Hi, this is my first time to use this library and I really wanna say it's amazing. But there is a minor issue confused me, in the example code from README.md, the strikethrough syntax of markdown is not work when I try to preview the README file use my IDEA.

Here looks like should be double `~` other than single `~`, I copied that into a online markdown editor and Google some tutorials, confirmed the correct markdown strikethrough syntax should be double `~`.