### PR TITLE
Fix confusing javadoc documentation for reportLinesUnchanged

### DIFF
--- a/java-diff-utils/src/main/java/com/github/difflib/text/DiffRowGenerator.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/text/DiffRowGenerator.java
@@ -492,11 +492,10 @@ public final class DiffRowGenerator {
         }
 
         /**
-         * Give the originial old and new text lines to Diffrow without any
-         * additional processing and without any tags to highlight the change.
+         * Report all lines without markup on the old or new text.
          *
          * @param val the value to set. Default: false.
-         * @return builder with configured reportLinesUnWrapped parameter
+         * @return builder with configured reportLinesUnchanged parameter
          */
         public Builder reportLinesUnchanged(final boolean val) {
             reportLinesUnchanged = val;


### PR DESCRIPTION
The original javadoc comments has problems:

- Typo on "origin<del>i</del>al"
- Typo on "reportLinesUn<del>Wrapped</del><ins>changed</ins>"
- Refers to internal code/processing logic over public API
- Can be interpreted to mean `DiffRow.Tag`s would be absent
- Does not clearly disambiguate that `reportLinesUnchanged` is not a flag to omit the lines with `DiffRow.Tag.EQUAL`

I spent hours trying to figure out why setting `reportLinesUnchanged` to `false` still reports the lines that are unchanged. I had to go through the source code to figure out what this method was for.