### PR TITLE
fix: parsing unified diff chunk headers

### DIFF
--- a/java-diff-utils/src/main/java/com/github/difflib/UnifiedDiffUtils.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/UnifiedDiffUtils.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 public final class UnifiedDiffUtils {
 
     private static final Pattern UNIFIED_DIFF_CHUNK_REGEXP = Pattern
-            .compile("^@@\\s+-(?:(\\d+)(?:,(\\d+))?)\\s+\\+(?:(\\d+)(?:,(\\d+))?)\\s+@@$");
+            .compile("^@@\\s+-(\\d+)(?:,(\\d+))?\\s+\\+(\\d+)(?:,(\\d+))?\\s+@@.*$");
     private static final String NULL_FILE_INDICATOR = "/dev/null";
 
     /**


### PR DESCRIPTION
The regex matching chunk headers does not account for unified diffs generated with `--show-function-line` (with GNU diffutils for example)

Currently this library parses only the following chunk header: `@@ -571,6 +571,12 @@`
But this is also valid: `@@ -571,6 +571,12 @@ .method public constructor <init>(Landro`

This also created a very odd error far down the call stack of this method call when `old_ln` and `new_ln` are both equal to `0` as a result of failing to parse the chunk headers.
https://github.com/java-diff-utils/java-diff-utils/blob/0f8365b35d30faa300b442cd90f57f95a60eaf45/java-diff-utils/src/main/java/com/github/difflib/UnifiedDiffUtils.java#L92-L93
