### PR TITLE
Fix a typo in DiffUtils.java javadocs

### DIFF
--- a/java-diff-utils/src/main/java/com/github/difflib/DiffUtils.java
+++ b/java-diff-utils/src/main/java/com/github/difflib/DiffUtils.java
@@ -42,7 +42,7 @@ public final class DiffUtils {
     /**
      * Sets the default diff algorithm factory to be used by all diff routines.
      *
-     * @param factory a {@link DiffAlgorithmFactory} represnting the new default diff algorithm factory.
+     * @param factory a {@link DiffAlgorithmFactory} representing the new default diff algorithm factory.
      */
     public static void withDefaultDiffAlgorithmFactory(DiffAlgorithmFactory factory) {
         DEFAULT_DIFF = factory;
@@ -52,9 +52,9 @@ public final class DiffUtils {
      * Computes the difference between two sequences of elements using the default diff algorithm.
      *
      * @param <T> a generic representing the type of the elements to be compared.
-     * @param original a {@link List} represnting the original sequence of elements. Must not be {@code null}.
-     * @param revised a {@link List} represnting the revised sequence of elements. Must not be {@code null}.
-     * @param progress a {@link DiffAlgorithmListener} represnting the progress listener. Can be {@code null}.
+     * @param original a {@link List} representing the original sequence of elements. Must not be {@code null}.
+     * @param revised a {@link List} representing the revised sequence of elements. Must not be {@code null}.
+     * @param progress a {@link DiffAlgorithmListener} representing the progress listener. Can be {@code null}.
      * @return The patch describing the difference between the original and revised sequences. Never {@code null}.
      */
     public static <T> Patch<T> diff(List<T> original, List<T> revised, DiffAlgorithmListener progress) {
@@ -65,8 +65,8 @@ public final class DiffUtils {
      * Computes the difference between two sequences of elements using the default diff algorithm.
      *
      * @param <T> a generic representing the type of the elements to be compared.
-     * @param original a {@link List} represnting the original sequence of elements. Must not be {@code null}.
-     * @param revised a {@link List} represnting the revised sequence of elements. Must not be {@code null}.
+     * @param original a {@link List} representing the original sequence of elements. Must not be {@code null}.
+     * @param revised a {@link List} representing the revised sequence of elements. Must not be {@code null}.
      * @return The patch describing the difference between the original and revised sequences. Never {@code null}.
      */
     public static <T> Patch<T> diff(List<T> original, List<T> revised) {
@@ -77,9 +77,9 @@ public final class DiffUtils {
      * Computes the difference between two sequences of elements using the default diff algorithm.
      *
      * @param <T> a generic representing the type of the elements to be compared.
-     * @param original a {@link List} represnting the original sequence of elements. Must not be {@code null}.
-     * @param revised a {@link List} represnting the revised sequence of elements. Must not be {@code null}.
-     * @param includeEqualParts a {@link boolean} represnting whether to include equal parts in the resulting patch.
+     * @param original a {@link List} representing the original sequence of elements. Must not be {@code null}.
+     * @param revised a {@link List} representing the revised sequence of elements. Must not be {@code null}.
+     * @param includeEqualParts a {@link boolean} representing whether to include equal parts in the resulting patch.
      * @return The patch describing the difference between the original and revised sequences. Never {@code null}.
      */
     public static <T> Patch<T> diff(List<T> original, List<T> revised, boolean includeEqualParts) {
@@ -89,9 +89,9 @@ public final class DiffUtils {
     /**
      * Computes the difference between two strings using the default diff algorithm.
      *
-     * @param sourceText a {@link String} represnting the original string. Must not be {@code null}.
-     * @param targetText a {@link String} represnting the revised string. Must not be {@code null}.
-     * @param progress a {@link DiffAlgorithmListener} represnting the progress listener. Can be {@code null}.
+     * @param sourceText a {@link String} representing the original string. Must not be {@code null}.
+     * @param targetText a {@link String} representing the revised string. Must not be {@code null}.
+     * @param progress a {@link DiffAlgorithmListener} representing the progress listener. Can be {@code null}.
      * @return The patch describing the difference between the original and revised strings. Never {@code null}.
      */
     public static Patch<String> diff(String sourceText, String targetText,
@@ -105,9 +105,9 @@ public final class DiffUtils {
      * Computes the difference between the original and revised list of elements
      * with default diff algorithm
      *
-     * @param source a {@link List} represnting the original text. Must not be {@code null}.
-     * @param target a {@link List} represnting the revised text. Must not be {@code null}.
-     * @param equalizer a {@link BiPredicate} represnting the equalizer object to replace the default compare
+     * @param source a {@link List} representing the original text. Must not be {@code null}.
+     * @param target a {@link List} representing the revised text. Must not be {@code null}.
+     * @param equalizer a {@link BiPredicate} representing the equalizer object to replace the default compare
      * algorithm (Object.equals). If {@code null} the default equalizer of the
      * default algorithm is used.
      * @return The patch describing the difference between the original and
@@ -131,10 +131,10 @@ public final class DiffUtils {
      * Computes the difference between the original and revised list of elements
      * with default diff algorithm
      *
-     * @param original a {@link List} represnting the original text. Must not be {@code null}.
-     * @param revised a {@link List} represnting the revised text. Must not be {@code null}.
-     * @param algorithm a {@link DiffAlgorithmI} represnting the diff algorithm. Must not be {@code null}.
-     * @param progress a {@link DiffAlgorithmListener} represnting the diff algorithm listener.
+     * @param original a {@link List} representing the original text. Must not be {@code null}.
+     * @param revised a {@link List} representing the revised text. Must not be {@code null}.
+     * @param algorithm a {@link DiffAlgorithmI} representing the diff algorithm. Must not be {@code null}.
+     * @param progress a {@link DiffAlgorithmListener} representing the diff algorithm listener.
      * @param includeEqualParts Include equal data parts into the patch.
      * @return The patch describing the difference between the original and
      * revised sequences. Never {@code null}.
@@ -154,9 +154,9 @@ public final class DiffUtils {
      * Computes the difference between the original and revised list of elements
      * with default diff algorithm
      *
-     * @param original a {@link List} represnting the original text. Must not be {@code null}.
-     * @param revised a {@link List} represnting the revised text. Must not be {@code null}.
-     * @param algorithm a {@link DiffAlgorithmI} represnting the diff algorithm. Must not be {@code null}.
+     * @param original a {@link List} representing the original text. Must not be {@code null}.
+     * @param revised a {@link List} representing the revised text. Must not be {@code null}.
+     * @param algorithm a {@link DiffAlgorithmI} representing the diff algorithm. Must not be {@code null}.
      * @return The patch describing the difference between the original and
      * revised sequences. Never {@code null}.
      */
@@ -169,8 +169,8 @@ public final class DiffUtils {
      * "trick" to make out of texts lists of characters, like DiffRowGenerator
      * does and merges those changes at the end together again.
      *
-     * @param original a {@link String} represnting the original text. Must not be {@code null}.
-     * @param revised a {@link String} represnting the revised text. Must not be {@code null}.
+     * @param original a {@link String} representing the original text. Must not be {@code null}.
+     * @param revised a {@link String} representing the revised text. Must not be {@code null}.
      * @return The patch describing the difference between the original and
      * revised sequences. Never {@code null}.
      */
@@ -194,8 +194,8 @@ public final class DiffUtils {
     /**
      * Applies the given patch to the original list and returns the revised list.
      *
-     * @param original a {@link List} represnting the original list.
-     * @param patch a {@link List} represnting the patch to apply.
+     * @param original a {@link List} representing the original list.
+     * @param patch a {@link List} representing the patch to apply.
      * @return the revised list.
      * @throws PatchFailedException if the patch cannot be applied.
      */
@@ -207,8 +207,8 @@ public final class DiffUtils {
     /**
      * Applies the given patch to the revised list and returns the original list.
      *
-     * @param revised a {@link List} represnting the revised list.
-     * @param patch a {@link Patch} represnting the patch to apply.
+     * @param revised a {@link List} representing the revised list.
+     * @param patch a {@link Patch} representing the patch to apply.
      * @return the original list.
      * @throws PatchFailedException if the patch cannot be applied.
      */


### PR DESCRIPTION
Fix spelling typographical errors in the word "representing" for DiffUtils docs